### PR TITLE
支持 Firefox 128+ MV3 

### DIFF
--- a/background.js
+++ b/background.js
@@ -15,7 +15,9 @@
 // ahead of prefetch. No internal retries for transport errors: a failed request
 // is simply re-issued by content.js when its cue is next active.
 
-importScripts("providers.js", "languages.js");
+// Firefox MV3 runs this as an event page and loads these scripts from the
+// manifest. Chromium runs it as a service worker, which needs importScripts.
+if (typeof importScripts === "function") importScripts("providers.js", "languages.js");
 const PROVIDERS = self.YTDS_PROVIDERS;
 const LANGS = self.YTDS_LANGS;
 

--- a/content.js
+++ b/content.js
@@ -236,6 +236,7 @@
   // an overlay that has quietly stopped translating, and a drag whose position
   // is never saved. Notice it, take the overlay away — this page belongs to the
   // new script now — and go quiet. The tab's next load gets a live one.
+  // Firefox can destroy the old script world before it removes its DOM.
   let orphaned = false;
   let navPollTimer = null;
   // Declared here, with the other things goOrphan has to switch off, so it can
@@ -401,6 +402,9 @@
     const player = getPlayer();
     if (!player) return null;
     if (overlay && overlay.isConnected) return overlay;
+
+    // Firefox can leave UI from a destroyed content-script world after reload.
+    for (const oldOverlay of player.querySelectorAll("#ytds-overlay")) oldOverlay.remove();
 
     overlay = document.createElement("div");
     overlay.id = "ytds-overlay";
@@ -817,6 +821,8 @@
       return;
     }
     if (toggleBtn && toggleBtn.isConnected) { updateToggleState(); return; }
+    // Remove the stale Firefox reload control before adding this instance's.
+    for (const oldToggle of rc.querySelectorAll(".ytds-toggle")) oldToggle.remove();
     toggleBtn = document.createElement("button");
     toggleBtn.className = "ytp-button ytds-toggle";
     toggleBtn.type = "button";

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extName__",
   "version": "3.6.0",
   "description": "__MSG_extDesc__",
-  "minimum_chrome_version": "102",
+  "minimum_chrome_version": "121",
   "permissions": ["storage"],
   "host_permissions": [
     "https://translate.googleapis.com/*"
@@ -25,7 +25,14 @@
     "https://api.deepl.com/*"
   ],
   "background": {
+    "scripts": ["providers.js", "languages.js", "background.js"],
     "service_worker": "background.js"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "yt-dual-subs@gythiro.github.io",
+      "strict_min_version": "128.0"
+    }
   },
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
## 支持 Firefox 128+ MV3 

### 变更
- 添加 Firefox 128+ MV3 支持
- Chrome 最低版本提升至121，（这是为了同时支持background.scripts和service_worker）
- 修复 Firefox 重载后字幕覆盖层和控制按钮残留

`minimum_chrome_version` 提升至 121：共享的 MV3 background 声明同时包含 Firefox 所需的 `background.scripts` 和 Chromium 所需的 `service_worker`；Chrome 121 是接受该共享声明的最低版本。

### 测试
- `web-ext lint` 零错误
- 核心流程和高级 Firefox 流程手动验证通过
- BYO provider runtime 未测试（无 key）